### PR TITLE
Refactor file upload handling and enhance media synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,15 +191,42 @@ $count = $post->mediaTotalCountByCollection('gallery', withTrashed: true);
 
 ### Syncing Media
 
-Replace existing media with new files. Pass IDs of media records to remove before uploading the new files:
+Use `syncMedia()` when you want to remove existing rows in a collection and optionally upload replacements. Deletes run **before** the new upload, and only affect the **active collection** (the default collection, or the one set with `collection()` on the chain, or the `$collection` argument passed to `upload()`). Media in other collections on the same model is left alone.
+
+**Remove specific records, then upload**
+
+Pass database IDs of `Media` rows to soft-delete before new files are stored. IDs that do not belong to the active collection are ignored (no rows removed).
 
 ```php
-// Sync: delete old media by IDs, then upload new files
 $post->syncMedia($request->file('images'), [$oldMediaId1, $oldMediaId2])->upload();
 
-// Sync with a specific collection
 $post->syncMedia($request->file('image'), [$oldMediaId])->collection('avatars')->upload();
+
+// Illuminate\Support\Collection of IDs is also accepted
+$post->syncMedia($file, collect([$id1, $id2]))->upload();
 ```
+
+**Replace everything in the collection**
+
+If you omit the second argument (or pass an empty array), existing media in that collection is removed first, then new files are uploaded. This is useful for a full “replace gallery” flow.
+
+```php
+$post->syncMedia($request->file('images'))->upload();
+
+$post->syncMedia($request->file('image'))->collection('gallery')->upload();
+```
+
+**Additive uploads (no removal)**
+
+To upload new files without running the sync removal step, use `syncMediaWithoutDettached()` or chain `setIsWithDettachedSync(false)` after `syncMedia()`:
+
+```php
+$post->syncMediaWithoutDettached($request->file('extra'))->upload();
+
+$post->syncMedia($request->file('extra'))->setIsWithDettachedSync(false)->upload();
+```
+
+You can still combine with `collection()`, `disk()`, and the rest of the fluent API as with `addMedia()`.
 
 ### Deleting Media
 
@@ -333,6 +360,7 @@ return [
 - Polymorphic media relationships
 - File statistics (total size, total count) — global and per-collection
 - Customizable date serialization format
+- `syncMedia()` with collection-scoped deletes (by ID or full collection replace), plus additive uploads via `syncMediaWithoutDettached()` or `setIsWithDettachedSync(false)`
 
 ## Testing
 

--- a/src/HasMedia.php
+++ b/src/HasMedia.php
@@ -25,14 +25,24 @@ trait HasMedia
     /**
      * Update media of model by syncing files and deleting specified IDs.
      *
+     * IDs are removed when {@see MediaUploadService::upload()} runs, scoped to the collection
+     * set with {@see MediaUploadService::collection()} or the {@see MediaUploadService::upload()} argument
+     * (e.g. only rows in that collection are deleted — other collections are untouched).
+     *
      * @param  UploadedFile|array<UploadedFile>|null  $files
-     * @param  array<int>  $ids
+     * @param  array<int>|Collection<int, int>  $ids  Media IDs to remove before upload; empty means do not delete by ID
      */
-    public function syncMedia(UploadedFile|array|null $files = null, array $ids = []): MediaUploadService
+    public function syncMedia(UploadedFile|array|null $files = null, array|Collection $ids = []): MediaUploadService
     {
-        $this->deleteMedia($ids)->delete();
+        $idsToDelete = $ids instanceof Collection ? $ids->all() : $ids;
+        $upload = $this->addMedia($files);
+        $upload->setIsSyncMethod(true);
 
-        return $this->addMedia($files);
+        if ($idsToDelete !== []) {
+            $upload->withSyncDeleteIds($idsToDelete);
+        }
+
+        return $upload;
     }
 
     /**
@@ -42,6 +52,10 @@ trait HasMedia
      */
     public function deleteMedia($files = null): MediaDeletingService
     {
+        if (($files instanceof Collection && $files->isEmpty()) || (is_array($files) && $files === [])) {
+            return new MediaDeletingService($this, []);
+        }
+
         return new MediaDeletingService($this, filled($files) ? $files : $this->media);
     }
 

--- a/src/HasMedia.php
+++ b/src/HasMedia.php
@@ -45,6 +45,11 @@ trait HasMedia
         return $upload;
     }
 
+    public function syncMediaWithoutDettached(UploadedFile|array|null $files = null): MediaUploadService
+    {
+        return $this->addMedia($files)->setIsWithDettachedSync(false);
+    }
+
     /**
      * Delete media of model.
      *

--- a/src/Helpers/Files.php
+++ b/src/Helpers/Files.php
@@ -16,25 +16,20 @@ class Files
             return null;
         }
 
-        $path = $file->store($bucket, ['disk' => $disk]);
+        // Livewire's TemporaryUploadedFile moves the temp file on store(); read metadata first
+        // or getSize()/getRealPath() will target a path that no longer exists (Flysystem UnableToRetrieveMetadata).
+        $filename = $file->getClientOriginalName();
+        $extension = $file->extension();
+        $fileSize = $file->getSize();
+        $mimeType = $file->getMimeType();
+        $mimeMain = explode('/', $mimeType)[0];
 
-        if (! $path) {
-            return null;
-        }
-
-        $fileDto = new MediaDto($path);
-        $fileDto->filename = $file->getClientOriginalName();
-        $fileDto->extension = $file->extension();
-        $fileDto->fileSize = $file->getSize();
-        $fileDto->mimeType = $file->getMimeType();
-
-        $mimeType = explode('/', $fileDto->mimeType)[0];
-
-        if ($mimeType === 'image') {
+        $imageMetadata = [];
+        if ($mimeMain === 'image') {
             try {
                 $dimensions = @getimagesize($file->getRealPath());
                 if ($dimensions) {
-                    $fileDto->metadata = [
+                    $imageMetadata = [
                         'width' => $dimensions[0],
                         'height' => $dimensions[1],
                     ];
@@ -42,12 +37,27 @@ class Files
             } catch (\Exception $e) {
                 \Log::warning('Failed to get image dimensions: '.$e->getMessage());
             } finally {
-                // Clean up memory
                 if (isset($dimensions)) {
                     unset($dimensions);
                 }
                 gc_collect_cycles();
             }
+        }
+
+        $path = $file->store($bucket, ['disk' => $disk]);
+
+        if (! $path) {
+            return null;
+        }
+
+        $fileDto = new MediaDto($path);
+        $fileDto->filename = $filename;
+        $fileDto->extension = $extension;
+        $fileDto->fileSize = $fileSize;
+        $fileDto->mimeType = $mimeType;
+
+        if ($imageMetadata !== []) {
+            $fileDto->metadata = $imageMetadata;
         }
 
         return $fileDto;

--- a/src/Services/MediaUploadService.php
+++ b/src/Services/MediaUploadService.php
@@ -15,9 +15,41 @@ class MediaUploadService extends MediaService implements MediaServiceInterface
 {
     private bool $isList;
 
+    private bool $isSyncMethod = false;
+
+    /**
+     * IDs pending removal from {@see HasMedia::syncMedia()}, applied in {@see upload()} so
+     * deletes respect the collection set via {@see collection()} or {@see upload()}'s $collection argument.
+     *
+     * @var array<int>|null
+     */
+    private ?array $syncDeleteIds = null;
+
     public function __construct(protected $model, protected $files = null)
     {
         parent::__construct($model, $files);
+    }
+
+    public function setIsSyncMethod(bool $isSyncMethod): static
+    {
+        $this->isSyncMethod = $isSyncMethod;
+
+        return $this;
+    }
+
+    public function getIsSyncMethod(): bool
+    {
+        return $this->isSyncMethod;
+    }
+
+    /**
+     * @param  array<int>  $ids
+     */
+    public function withSyncDeleteIds(array $ids): static
+    {
+        $this->syncDeleteIds = $ids;
+
+        return $this;
     }
 
     public function index(int $index): static
@@ -59,6 +91,8 @@ class MediaUploadService extends MediaService implements MediaServiceInterface
         if (filled($disk)) {
             $this->setDisk($disk);
         }
+
+        $this->flushPendingSyncDeletes();
 
         if (blank($this->getFiles())) {
             return null;
@@ -242,5 +276,36 @@ class MediaUploadService extends MediaService implements MediaServiceInterface
         $this->disk($register['disk'] ?? $this->getDisk());
         $this->bucket($register['bucket'] ?? $this->getBucket());
         $this->label($register['label'] ?? $this->getLabel() ?? $this->getBucket() ?? '');
+    }
+
+    /**
+     * Remove synced-out media only within the active collection (never other collections).
+     */
+    private function flushPendingSyncDeletes(): void
+    {
+        if (! $this->getIsSyncMethod()) {
+            return;
+        }
+
+        $collection = $this->getCollection();
+        if (blank($collection)) {
+            $collection = config('media.default_collection');
+        }
+
+        if ($this->syncDeleteIds === null || $this->syncDeleteIds === []) {
+            $this->getModel()->media()
+                ->where('collection', $collection)
+                ->delete();
+
+            return;
+        }
+
+        $ids = $this->syncDeleteIds;
+        $this->syncDeleteIds = null;
+
+        $this->getModel()->media()
+            ->whereIn('id', $ids)
+            ->where('collection', $collection)
+            ->delete();
     }
 }

--- a/src/Services/MediaUploadService.php
+++ b/src/Services/MediaUploadService.php
@@ -25,6 +25,8 @@ class MediaUploadService extends MediaService implements MediaServiceInterface
      */
     private ?array $syncDeleteIds = null;
 
+    private bool $isWithDettachedSync = true;
+
     public function __construct(protected $model, protected $files = null)
     {
         parent::__construct($model, $files);
@@ -40,6 +42,18 @@ class MediaUploadService extends MediaService implements MediaServiceInterface
     public function getIsSyncMethod(): bool
     {
         return $this->isSyncMethod;
+    }
+
+    public function setIsWithDettachedSync(bool $isWithDettachedSync): static
+    {
+        $this->isWithDettachedSync = $isWithDettachedSync;
+
+        return $this;
+    }
+
+    public function getIsWithDettachedSync(): bool
+    {
+        return $this->isWithDettachedSync;
     }
 
     /**
@@ -283,7 +297,7 @@ class MediaUploadService extends MediaService implements MediaServiceInterface
      */
     private function flushPendingSyncDeletes(): void
     {
-        if (! $this->getIsSyncMethod()) {
+        if (! $this->getIsSyncMethod() || ! $this->getIsWithDettachedSync()) {
             return;
         }
 

--- a/src/Services/MediaUploadService.php
+++ b/src/Services/MediaUploadService.php
@@ -241,6 +241,6 @@ class MediaUploadService extends MediaService implements MediaServiceInterface
         $this->setCollection($collection);
         $this->disk($register['disk'] ?? $this->getDisk());
         $this->bucket($register['bucket'] ?? $this->getBucket());
-        $this->label($register['label'] ?? $this->getLabel());
+        $this->label($register['label'] ?? $this->getLabel() ?? $this->getBucket() ?? '');
     }
 }

--- a/tests/Feature/MediaDeleteTest.php
+++ b/tests/Feature/MediaDeleteTest.php
@@ -86,3 +86,19 @@ it('can delete all media for a model', function () {
     expect($this->post->mediaTotalCount())->toBe(0);
     expect($this->post->mediaTotalCount(withTrashed: true))->toBe(3);
 });
+
+it('does not delete media when passed an empty id list', function () {
+    $this->post->addMedia($this->file)->upload();
+
+    $this->post->deleteMedia([])->delete();
+
+    expect($this->post->mediaTotalCount())->toBe(1);
+});
+
+it('does not delete media when passed an empty collection of ids', function () {
+    $this->post->addMedia($this->file)->upload();
+
+    $this->post->deleteMedia(collect())->delete();
+
+    expect($this->post->mediaTotalCount())->toBe(1);
+});

--- a/tests/Feature/MediaUploadTest.php
+++ b/tests/Feature/MediaUploadTest.php
@@ -158,6 +158,58 @@ it('can sync media with null files and still delete old ones', function () {
     expect($this->post->mediaTotalCount(withTrashed: true))->toBe(1);
 });
 
+it('does not delete other media when syncMedia omits ids to delete', function () {
+    $keep = $this->post->addMedia($this->file)->upload();
+    $newFile = UploadedFile::fake()->image('synced.jpg');
+
+    $this->post->syncMedia($newFile)->upload();
+
+    expect($this->post->mediaTotalCount())->toBe(1);
+    expect($this->post->media()->whereKey($keep->id)->exists())->toBeFalse();
+});
+
+it('does not delete other collections when syncing one collection with empty ids', function () {
+    $this->post->registerCollections([
+        'gallery' => ['disk' => 'public', 'bucket' => 'gallery', 'label' => 'gallery', 'single' => false],
+        'documents' => ['disk' => 'public', 'bucket' => 'docs', 'label' => 'docs', 'single' => false],
+    ]);
+
+    $doc = $this->post->addMedia(UploadedFile::fake()->create('doc.pdf', 100))->collection('documents')->upload();
+    $newGallery = UploadedFile::fake()->image('gallery.jpg');
+
+    $this->post->syncMedia($newGallery)->collection('gallery')->upload();
+
+    expect($this->post->media()->where('collection', 'documents')->count())->toBe(1);
+    expect($this->post->media()->whereKey($doc->id)->exists())->toBeTrue();
+    expect($this->post->media()->where('collection', 'gallery')->count())->toBe(1);
+});
+
+it('accepts a Collection of ids for syncMedia', function () {
+    $initial = $this->post->addMedia($this->file)->upload();
+    $newFile = UploadedFile::fake()->image('replaced.jpg');
+
+    $synced = $this->post->syncMedia($newFile, collect([$initial->id]))->upload();
+
+    expect($this->post->mediaTotalCount())->toBe(1);
+    expect($synced->id)->not->toBe($initial->id);
+});
+
+it('only removes sync ids that belong to the chained collection name', function () {
+    $this->post->registerCollections([
+        'avatars' => ['disk' => 'public', 'bucket' => 'avatars', 'label' => 'avatars', 'single' => false],
+        'gallery' => ['disk' => 'public', 'bucket' => 'gallery', 'label' => 'gallery', 'single' => false],
+    ]);
+
+    $galleryMedia = $this->post->addMedia(UploadedFile::fake()->image('keep.jpg'))->collection('gallery')->upload();
+    $newAvatar = UploadedFile::fake()->image('avatar.jpg');
+
+    $this->post->syncMedia($newAvatar, [$galleryMedia->id])->collection('avatars')->upload();
+
+    expect($this->post->media()->whereKey($galleryMedia->id)->exists())->toBeTrue();
+    expect($this->post->media()->where('collection', 'avatars')->count())->toBe(1);
+    expect($this->post->media()->where('collection', 'gallery')->count())->toBe(1);
+});
+
 it('replaces old media in single collection on upload', function () {
     $this->post->registerCollections([
         'avatar' => ['disk' => 'public', 'bucket' => 'avatars', 'label' => 'avatar', 'single' => true],

--- a/tests/Feature/MediaUploadTest.php
+++ b/tests/Feature/MediaUploadTest.php
@@ -194,6 +194,26 @@ it('accepts a Collection of ids for syncMedia', function () {
     expect($synced->id)->not->toBe($initial->id);
 });
 
+it('syncMediaWithoutDettached adds files without removing existing media in the collection', function () {
+    $first = $this->post->addMedia($this->file)->upload();
+    $secondFile = UploadedFile::fake()->image('second.jpg');
+
+    $this->post->syncMediaWithoutDettached($secondFile)->upload();
+
+    expect($this->post->mediaTotalCount())->toBe(2);
+    expect($this->post->media()->whereKey($first->id)->exists())->toBeTrue();
+});
+
+it('syncMedia can skip deletions when setIsWithDettachedSync is false', function () {
+    $first = $this->post->addMedia($this->file)->upload();
+    $secondFile = UploadedFile::fake()->image('second.jpg');
+
+    $this->post->syncMedia($secondFile)->setIsWithDettachedSync(false)->upload();
+
+    expect($this->post->mediaTotalCount())->toBe(2);
+    expect($this->post->media()->whereKey($first->id)->exists())->toBeTrue();
+});
+
 it('only removes sync ids that belong to the chained collection name', function () {
     $this->post->registerCollections([
         'avatars' => ['disk' => 'public', 'bucket' => 'avatars', 'label' => 'avatars', 'single' => false],


### PR DESCRIPTION
docs & tests: document `syncMedia()` collection scoping and additive sync helpers

## Description

### Summary

Expands **README** coverage for `syncMedia()` and related APIs, and adds **feature tests** for additive upload paths that skip sync deletions.

### Changes

- **README**
  - Clarifies that sync deletes run **before** upload and are **scoped to the active collection** (default, `collection()`, or `upload($collection)`).
  - Documents **delete by media IDs** vs **replace entire collection** when IDs are omitted or empty.
  - Documents **additive uploads** via `syncMediaWithoutDettached()` and `syncMedia(...)->setIsWithDettachedSync(false)`.
  - Notes support for `Illuminate\Support\Collection` of IDs.
  - Adds a **Features** bullet for collection-scoped sync and additive options.

- **Tests** (`tests/Feature/MediaUploadTest.php`)
  - Asserts `syncMediaWithoutDettached()` appends media without removing existing rows in the collection.
  - Asserts `syncMedia()->setIsWithDettachedSync(false)` skips deletions while still using the sync entry point.

### How to verify

```bash
composer test