### PR TITLE
feat: add orderByIndexMedia method to HasMedia trait for index-based media ordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.phpunit.result.cache
 /vendor
 /composer.lock
 /.phpunit.cache

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ return [
 - File statistics (total size, total count) — global and per-collection
 - Customizable date serialization format
 - `syncMedia()` with collection-scoped deletes (by ID or full collection replace), plus additive uploads via `syncMediaWithoutDettached()` or `setIsWithDettachedSync(false)`
-- `orderByIndex()` for index-based media ordering across all retrieval methods
+- `orderByIndexMedia()` for index-based media ordering across all retrieval methods
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,27 @@ $count = $post->mediaTotalCountByCollection('gallery');
 $count = $post->mediaTotalCountByCollection('gallery', withTrashed: true);
 ```
 
+### Ordering Media by Index
+
+Use `orderByIndexMedia()` to order media results by the `index` column. This is enabled by default, so media is automatically sorted by index unless explicitly disabled. default value for `orderByIndexMedia()` method is `true` so you can remove it when you want to order by index.
+
+```php
+// Order by index (enabled by default)
+$media = $post->orderByIndexMedia()->getMedia();
+$media = $post->orderByIndexMedia()->getCollection('gallery');
+$urls  = $post->orderByIndexMedia()->getCollectionUrls();
+$array = $post->orderByIndexMedia()->getCollectionArray('gallery');
+
+// Works with filter methods too
+$images = $post->orderByIndexMedia()->mediaByMimeType('image/jpeg');
+$approved = $post->orderByIndexMedia()->mediaApproved();
+
+// Disable index ordering
+$media = $post->orderByIndexMedia(false)->getMedia();
+```
+
+The `orderByIndexMedia()` method is fluent and can be chained with any media retrieval method that returns a collection or query result.
+
 ### Syncing Media
 
 Use `syncMedia()` when you want to remove existing rows in a collection and optionally upload replacements. Deletes run **before** the new upload, and only affect the **active collection** (the default collection, or the one set with `collection()` on the chain, or the `$collection` argument passed to `upload()`). Media in other collections on the same model is left alone.
@@ -374,6 +395,7 @@ return [
 - File statistics (total size, total count) — global and per-collection
 - Customizable date serialization format
 - `syncMedia()` with collection-scoped deletes (by ID or full collection replace), plus additive uploads via `syncMediaWithoutDettached()` or `setIsWithDettachedSync(false)`
+- `orderByIndex()` for index-based media ordering across all retrieval methods
 
 ## Testing
 

--- a/src/HasMedia.php
+++ b/src/HasMedia.php
@@ -12,6 +12,26 @@ trait HasMedia
 {
     public ?array $registerMediaCollections = null;
 
+    public bool $useIndexMedia = true;
+
+    /**
+     * Enable ordering media by index column.
+     */
+    public function orderByIndexMedia(bool $enabled = true): static
+    {
+        $this->useIndexMedia = $enabled;
+
+        return $this;
+    }
+
+    /**
+     * Apply index ordering to a query if useIndex is enabled.
+     */
+    private function applyIndexOrder($query)
+    {
+        return $this->useIndexMedia ? $query->orderBy('index') : $query;
+    }
+
     /**
      * Add media for model.
      *
@@ -139,10 +159,11 @@ trait HasMedia
      */
     public function mediaByMimeType(string $mimeType, bool $withTrashed = false): Collection
     {
-        return $this->media()
-            ->where('mimetype', $mimeType)
-            ->when($withTrashed, fn ($q) => $q->withTrashed())
-            ->get();
+        return $this->applyIndexOrder(
+            $this->media()
+                ->where('mimetype', $mimeType)
+                ->when($withTrashed, fn ($q) => $q->withTrashed())
+        )->get();
     }
 
     /**
@@ -152,11 +173,12 @@ trait HasMedia
     {
         $collection = $collection ?? config('media.default_collection');
 
-        return $this->media()
-            ->where('mimetype', $mimeType)
-            ->where('collection', $collection)
-            ->when($withTrashed, fn ($q) => $q->withTrashed())
-            ->get();
+        return $this->applyIndexOrder(
+            $this->media()
+                ->where('mimetype', $mimeType)
+                ->where('collection', $collection)
+                ->when($withTrashed, fn ($q) => $q->withTrashed())
+        )->get();
     }
 
     /**
@@ -166,10 +188,11 @@ trait HasMedia
      */
     public function mediaApproved(bool $approved = true, bool $withTrashed = false): Collection
     {
-        return $this->media()
-            ->where('approved', $approved)
-            ->when($withTrashed, fn ($q) => $q->withTrashed())
-            ->get();
+        return $this->applyIndexOrder(
+            $this->media()
+                ->where('approved', $approved)
+                ->when($withTrashed, fn ($q) => $q->withTrashed())
+        )->get();
     }
 
     /**
@@ -190,7 +213,7 @@ trait HasMedia
      */
     public function getMedia(): Collection
     {
-        return $this->media()->get();
+        return $this->applyIndexOrder($this->media())->get();
     }
 
     /**
@@ -242,6 +265,8 @@ trait HasMedia
         }
 
         $query = $this->media()->where('collection', $name);
+
+        $query = $this->applyIndexOrder($query);
 
         return ($register['single'] ?? false) ? $query->first() : $query->get();
     }

--- a/tests/Feature/MediaUseIndexTest.php
+++ b/tests/Feature/MediaUseIndexTest.php
@@ -1,0 +1,198 @@
+<?php
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Storage;
+use Waad\Media\Media;
+
+beforeEach(function () {
+    Storage::fake('public');
+    $this->post = createPost();
+    $this->file = UploadedFile::fake()->image('test.jpg', 50, 50);
+});
+
+afterEach(function () {
+    if (isset($this->post)) {
+        $this->post->media()->forceDelete();
+    }
+});
+
+// --- orderByIndex basic ---
+
+it('returns the model instance for fluent chaining', function () {
+    expect($this->post->orderByIndexMedia())->toBeInstanceOf(\Tests\App\Models\Post::class);
+});
+
+it('defaults to true', function () {
+    expect($this->post->useIndexMedia)->toBeTrue();
+});
+
+it('can be set to false', function () {
+    $this->post->orderByIndexMedia(false);
+    expect($this->post->useIndexMedia)->toBeFalse();
+});
+
+it('can be re-enabled', function () {
+    $this->post->orderByIndexMedia(false)->orderByIndexMedia();
+    expect($this->post->useIndexMedia)->toBeTrue();
+});
+
+// --- getMedia ---
+
+it('orders getMedia by index when orderByIndex is enabled', function () {
+    $media1 = $this->post->addMedia($this->file)->index(3)->upload();
+    $media2 = $this->post->addMedia(UploadedFile::fake()->image('test2.jpg'))->index(1)->upload();
+    $media3 = $this->post->addMedia(UploadedFile::fake()->image('test3.jpg'))->index(2)->upload();
+
+    $media = $this->post->orderByIndexMedia()->getMedia();
+
+    expect($media)->toHaveCount(3);
+    expect($media->first()->id)->toBe($media2->id);
+    expect($media->last()->id)->toBe($media1->id);
+});
+
+it('does not order getMedia by index when orderByIndex is not enabled', function () {
+    $media1 = $this->post->addMedia($this->file)->upload();
+    $media2 = $this->post->addMedia(UploadedFile::fake()->image('test2.jpg'))->upload();
+
+    $media = $this->post->getMedia();
+
+    expect($media)->toHaveCount(2);
+    expect($media->first()->id)->toBe($media1->id);
+    expect($media->last()->id)->toBe($media2->id);
+});
+
+// --- getCollection ---
+
+it('orders getCollection by index when orderByIndex is enabled', function () {
+    $media1 = $this->post->addMedia($this->file)->index(2)->upload();
+    $media2 = $this->post->addMedia(UploadedFile::fake()->image('test2.jpg'))->index(1)->upload();
+
+    $media = $this->post->orderByIndexMedia()->getCollection();
+
+    expect($media)->toHaveCount(2);
+    expect($media->first()->id)->toBe($media2->id);
+    expect($media->last()->id)->toBe($media1->id);
+});
+
+// --- getCollectionArray ---
+
+it('orders getCollectionArray by index when orderByIndex is enabled', function () {
+    $media1 = $this->post->addMedia($this->file)->index(2)->upload();
+    $media2 = $this->post->addMedia(UploadedFile::fake()->image('test2.jpg'))->index(1)->upload();
+
+    $media = $this->post->orderByIndexMedia()->getCollectionArray();
+
+    expect($media)->toHaveCount(2);
+    expect($media[0]['id'])->toBe($media2->id);
+    expect($media[1]['id'])->toBe($media1->id);
+});
+
+// --- getCollectionUrls ---
+
+it('orders getCollectionUrls by index when orderByIndex is enabled', function () {
+    $media1 = $this->post->addMedia($this->file)->index(2)->upload();
+    $media2 = $this->post->addMedia(UploadedFile::fake()->image('test2.jpg'))->index(1)->upload();
+
+    $urls = $this->post->orderByIndexMedia()->getCollectionUrls();
+
+    expect($urls)->toHaveCount(2);
+    expect($urls->first())->toBe($media2->full_url);
+    expect($urls->last())->toBe($media1->full_url);
+});
+
+// --- mediaByMimeType ---
+
+it('orders mediaByMimeType by index when orderByIndex is enabled', function () {
+    $media1 = $this->post->addMedia($this->file)->index(3)->upload();
+    $media2 = $this->post->addMedia(UploadedFile::fake()->image('test2.jpg'))->index(1)->upload();
+    $media3 = $this->post->addMedia(UploadedFile::fake()->image('test3.jpg'))->index(2)->upload();
+
+    $media = $this->post->orderByIndexMedia()->mediaByMimeType('image/jpeg');
+
+    expect($media)->toHaveCount(3);
+    expect($media->first()->id)->toBe($media2->id);
+    expect($media->last()->id)->toBe($media1->id);
+});
+
+// --- mediaByMimeTypeByCollection ---
+
+it('orders mediaByMimeTypeByCollection by index when orderByIndex is enabled', function () {
+    $this->post->registerCollections([
+        'gallery' => ['disk' => 'public', 'bucket' => 'gallery', 'label' => 'gallery', 'single' => false],
+    ]);
+
+    $media1 = $this->post->addMedia($this->file)->collection('gallery')->index(2)->upload();
+    $media2 = $this->post->addMedia(UploadedFile::fake()->image('test2.jpg'))->collection('gallery')->index(1)->upload();
+
+    $media = $this->post->orderByIndexMedia()->mediaByMimeTypeByCollection('image/jpeg', 'gallery');
+
+    expect($media)->toHaveCount(2);
+    expect($media->first()->id)->toBe($media2->id);
+    expect($media->last()->id)->toBe($media1->id);
+});
+
+// --- mediaApproved ---
+
+it('orders mediaApproved by index when orderByIndex is enabled', function () {
+    $media1 = $this->post->addMedia($this->file)->index(3)->upload();
+    $media2 = $this->post->addMedia(UploadedFile::fake()->image('test2.jpg'))->index(1)->upload();
+    $media3 = $this->post->addMedia(UploadedFile::fake()->image('test3.jpg'))->index(2)->upload();
+    $media3->disApprove();
+
+    $media = $this->post->orderByIndexMedia()->mediaApproved();
+
+    expect($media)->toHaveCount(2);
+    expect($media->first()->id)->toBe($media2->id);
+    expect($media->last()->id)->toBe($media1->id);
+});
+
+// --- getCollectionGroups ---
+
+it('orders getCollectionGroups by index when orderByIndex is enabled', function () {
+    $this->post->registerCollections([
+        'gallery' => ['disk' => 'public', 'bucket' => 'gallery', 'label' => 'gallery', 'single' => false],
+    ]);
+
+    $media1 = $this->post->addMedia($this->file)->collection('gallery')->index(2)->upload();
+    $media2 = $this->post->addMedia(UploadedFile::fake()->image('test2.jpg'))->collection('gallery')->index(1)->upload();
+
+    $groups = $this->post->orderByIndexMedia()->getCollectionGroups();
+
+    expect($groups['gallery'])->toHaveCount(2);
+    expect($groups['gallery'][0]->id)->toBe($media2->id);
+    expect($groups['gallery'][1]->id)->toBe($media1->id);
+});
+
+// --- getCollectionGroupUrls ---
+
+it('orders getCollectionGroupUrls by index when orderByIndex is enabled', function () {
+    $this->post->registerCollections([
+        'gallery' => ['disk' => 'public', 'bucket' => 'gallery', 'label' => 'gallery', 'single' => false],
+    ]);
+
+    $media1 = $this->post->addMedia($this->file)->collection('gallery')->index(2)->upload();
+    $media2 = $this->post->addMedia(UploadedFile::fake()->image('test2.jpg'))->collection('gallery')->index(1)->upload();
+
+    $urls = $this->post->orderByIndexMedia()->getCollectionGroupUrls();
+
+    expect($urls)->toHaveCount(2);
+    expect($urls->first())->toBe($media2->full_url);
+    expect($urls->last())->toBe($media1->full_url);
+});
+
+// --- single collection ---
+
+it('returns single collection media by index when orderByIndex is enabled', function () {
+    $this->post->registerCollections([
+        'avatar' => ['disk' => 'public', 'bucket' => 'avatars', 'label' => 'avatar', 'single' => true],
+    ]);
+
+    $media1 = $this->post->addMedia($this->file)->collection('avatar')->index(2)->upload();
+    $media2 = $this->post->addMedia(UploadedFile::fake()->image('test2.jpg'))->collection('avatar')->index(1)->upload();
+
+    $media = $this->post->orderByIndexMedia()->getCollection('avatar');
+
+    expect($media)->toBeInstanceOf(Media::class);
+    expect($media->id)->toBe($media2->id);
+});


### PR DESCRIPTION
## Description

Add `orderByIndexMedia()` fluent method to the `HasMedia` trait that enables ordering media results by the `index` column. The feature defaults to enabled (`true`), so media is ordered by index automatically unless explicitly disabled.

### Changes

- **`HasMedia` trait**: Added `$useIndexMedia` property (default `true`), `orderByIndexMedia()` fluent method, and private `applyIndexOrder()` helper
- **Media retrieval methods updated** to respect the index ordering flag:
  - `getMedia()`
  - `getCollection()`
  - `getCollectionArray()`
  - `getCollectionUrls()`
  - `getCollectionGroups()` / `getCollectionGroupUrls()`
  - `mediaByMimeType()`
  - `mediaByMimeTypeByCollection()`
  - `mediaApproved()`

### Usage

```php
// Order by index (enabled by default)
$model->orderByIndexMedia()->getMedia();
$model->orderByIndexMedia()->getCollection('gallery');
$model->orderByIndexMedia()->getCollectionUrls();

// Disable index ordering
$model->orderByIndexMedia(false)->getMedia();
```

### Tests
Added tests/Feature/MediaUseIndexTest.php with 15 test cases covering fluent chaining, enable/disable behavior, and ordering across all affected methods.